### PR TITLE
Was getting bitten by this...

### DIFF
--- a/autoload/SingleCompile.vim
+++ b/autoload/SingleCompile.vim
@@ -1922,7 +1922,7 @@ function! SingleCompile#ViewResult(async) " view the running result {{{1
         exec l:result_bufwinnr.'wincmd w'
         let l:save_cursor = getpos(".")
         setl modifiable
-            exec "g//d"
+            exec "g/./d"
         setl nomodifiable
     endif
 


### PR DESCRIPTION
Single compile secretly chooses a compiler the first time you compile and it's not the one at the top of the list. Let's give a hint about the current situation when selecting a compiler so that someone can at least know to put it in their vimrc if necessary (like I did).
