### PR TITLE
add feature silent compile when quickfix is enable

### DIFF
--- a/autoload/SingleCompile.vim
+++ b/autoload/SingleCompile.vim
@@ -521,6 +521,11 @@ function! s:Initialize() "{{{1
         let g:SingleCompile_usequickfix = 1
     endif
 
+    if !exists('g:SingleCompile_silentcompileifshowquickfix') ||
+                \type(g:SingleCompile_silentcompileifshowquickfix) != type(0)
+        unlet! g:SingleCompile_silentcompileifshowquickfix
+        let g:SingleCompile_silentcompileifshowquickfix = 0
+    endif
 
     " Initialize async mode
     if g:SingleCompile_asyncrunmode !=? 'none'
@@ -1081,14 +1086,24 @@ function! s:CompileInternal(arg_list, async) " compile only {{{1
 
         let &l:makeprg = l:compile_cmd
         let &l:shellpipe = s:GetShellPipe(0)
-        exec 'make'.' '.l:compile_args
+        let l:prefix_args = ''
+        let l:silentcompile = g:SingleCompile_silentcompileifshowquickfix &&
+                    \ g:SingleCompile_showquickfixiferror &&
+                    \ has("gui_running")
+
+        if l:silentcompile
+            let l:prefix_args = 'silent '
+        endif
+        exec l:prefix_args.'make'.' '.l:compile_args
 
         " check whether compiling is successful, if not, show the return value
         " with error message highlighting and set the return value to 1
         if v:shell_error != 0
-            echo ' '
-            call s:ShowMessage(
-                        \ 'Compiler exit code is '.v:shell_error)
+            if !l:silentcompile
+                echo ' '
+                call s:ShowMessage(
+                            \ 'Compiler exit code is '.v:shell_error)
+            endif
             let l:toret = 1
         endif
 

--- a/doc/SingleCompile.txt
+++ b/doc/SingleCompile.txt
@@ -356,9 +356,10 @@ your vimrc file:
 >
  let g:SingleCompile_showquickfixiferror = 1
 <
-The default value of g:SingleCompile_showquickfixiferror is 0. Note that this
-option will be ignored if you are using interpreting languages on Windows,
-such as python, ruby.
+The default value of g:SingleCompile_showquickfixiferror is 0. You may want to
+use this option with |SingleCompile-silentcompileifshowquickfix|. Note that
+this option will be ignored if you are using interpreting languages on
+Windows, such as python, ruby.
 
                                             *SingleCompile-showresultafterrun*
 If "tee" command is available on your system, copy the following line to your
@@ -370,6 +371,16 @@ run the program:
 This option is only valid for synchronous run. That is to say, asynchronous
 run is not affected by this option. The default value of
 g:SingleCompile_showresultafterrun is 0. Also see |:SCViewResult|.
+
+                                    *SingleCompile-silentcompileifshowquickfix*
+Avoid the additional hit of enter when using quickfix feature to compile.
+This is done by dismisses the output of the compilation (:silent make).  This
+feature is only valid when showquickfixiferror is enabled.  This feature won't
+enable on terminal because of the problem of screen refresh.
+>
+ let g:SingleCompile_silentcompileifshowquickfix = 1
+<
+This is not default enabled for compatible.
 
                                             *SingleCompile-usedialog*
 If you want SingleCompile to show message in a dialog, add the


### PR DESCRIPTION
```
                                *SingleCompile-silentcompileifshowquickfix*
```

Avoid the additional hit of enter when using quickfix feature to compile.
This feature is only valid when showquickfixiferror is enabled.

>  let g:SingleCompile_silentcompileifshowquickfix = 1
> <
> This is not default enabled for compatible.
