### PR TITLE
add g:SingleCompile_showquickfixifwarning and its document

### DIFF
--- a/autoload/SingleCompile.vim
+++ b/autoload/SingleCompile.vim
@@ -503,6 +503,13 @@ function! s:Initialize() "{{{1
         let g:SingleCompile_showquickfixiferror = 0
     endif
 
+    if !exists('g:SingleCompile_showquickfixifwarning') ||
+                \type(g:SingleCompile_showquickfixifwarning) != type(0)
+        unlet! g:SingleCompile_showquickfixifwarning
+        let g:SingleCompile_showquickfixifwarning =
+                    \g:SingleCompile_showquickfixiferror
+    endif
+
     if !exists('g:SingleCompile_showresultafterrun') ||
                 \type(g:SingleCompile_showresultafterrun) != type(0)
         unlet! g:SingleCompile_showresultafterrun
@@ -1118,10 +1125,15 @@ function! s:CompileInternal(arg_list, async) " compile only {{{1
 
     " show the quickfix window if error occurs, quickfix is used and
     " g:SingleCompile_showquickfixiferror is set to nonzero
-    if (l:toret == 1 || l:toret == 3) &&
-                \ g:SingleCompile_showquickfixiferror && 
-                \ s:ShouldQuickfixBeUsed()
-        cope
+    if g:SingleCompile_showquickfixiferror && s:ShouldQuickfixBeUsed()
+        " We have error
+        if l:toret == 1 || l:toret == 3
+            " wordaround when the compiler file is broken
+            cope
+        " We may have warning
+        elseif g:SingleCompile_showquickfixifwarning
+            cw
+        endif
     endif
 
     " if tee is available, and we are running an interpreting language source

--- a/doc/SingleCompile.txt
+++ b/doc/SingleCompile.txt
@@ -360,6 +360,16 @@ The default value of g:SingleCompile_showquickfixiferror is 0. Note that this
 option will be ignored if you are using interpreting languages on Windows,
 such as python, ruby.
 
+                                          *SingleCompile-showquickfixifwarning*
+If |quickfix| is enabled and used, and you want the quickfix window to show
+automatically if there is a compilation warning.  This setting is only valid
+when g:SingleCompile_showquickfixiferror = 1.
+>
+ let g:SingleCompile_showquickfixifwarning = 0
+<
+The default value of g:SingleCompile_showquickfixifwarning is as same as
+g:SingleCompile_showquickfixiferror.  You don't want miss a warning, will you?
+
                                             *SingleCompile-showresultafterrun*
 If "tee" command is available on your system, copy the following line to your
 vimrc file will make vim show the result of the run automatically after you


### PR DESCRIPTION
```
                                      *SingleCompile-showquickfixifwarning*
```

If |quickfix| is enabled and used, and you want the quickfix window to show
automatically if there is a compilation warning.  This setting is only valid
when g:SingleCompile_showquickfixiferror = 1.

<pre>
 let g:SingleCompile_showquickfixiferror = 0
</pre>

The default value of g:SingleCompile_showquickfixiferror is as same as
g:SingleCompile_showquickfixiferror.  You won't miss a warning, will you?
