### PR TITLE
Fix compiler warnings for MSVC 2008/2010

### DIFF
--- a/autoload/SingleCompile/templates/c.vim
+++ b/autoload/SingleCompile/templates/c.vim
@@ -43,7 +43,7 @@ function! SingleCompile#templates#c#Initialize()
                     \ 'vim-compiler' : 'msvc'})
         call SingleCompile#SetCompilerTemplate('c', 'msvc90',
                     \ 'Microsoft Visual C++ 2008 (9.0)', 'cl90',
-                    \ '-o $(FILE_TITLE)$', g:SingleCompile_common_run_command,
+                    \ ' ', g:SingleCompile_common_run_command,
                     \ function('SingleCompile#DetectMicrosoftVC'))
         call SingleCompile#SetCompilerTemplateByDict('c', 'msvc90', {
                     \ 'pre-do' : function('SingleCompile#PredoMicrosoftVC'),

--- a/autoload/SingleCompile/templates/cpp.vim
+++ b/autoload/SingleCompile/templates/cpp.vim
@@ -44,7 +44,7 @@ function! SingleCompile#templates#cpp#Initialize()
                     \ 'vim-compiler' : 'msvc'})
         call SingleCompile#SetCompilerTemplate('cpp', 'msvc90',
                     \ 'Microsoft Visual C++ 2008 (9.0)', 'cl90',
-                    \ '-o $(FILE_TITLE)$', g:SingleCompile_common_run_command,
+                    \ '/EHsc', g:SingleCompile_common_run_command,
                     \ function('SingleCompile#DetectMicrosoftVC'))
         call SingleCompile#SetCompilerTemplateByDict('cpp', 'msvc90', {
                     \ 'pre-do' : function('SingleCompile#PredoMicrosoftVC'),


### PR DESCRIPTION
1) Option "-o" causes compiler warning about its deprecation. By default compiler gives the output file a default name using the base name of the first source or object file specified on the command line, so we can just remove "-o" from options

2) When building C++ files, compiler emits warning 4530 (http://msdn.microsoft.com/en-us/library/2axwkyt4.aspx). /EHsc option is added to fix that
