### PR TITLE
Fix name of output file for Go on Windows

### DIFF
--- a/autoload/SingleCompile/templates/go.vim
+++ b/autoload/SingleCompile/templates/go.vim
@@ -19,7 +19,7 @@
 
 function! SingleCompile#templates#go#Initialize()
     call SingleCompile#SetCompilerTemplate('go', 'go', 'Go',
-                \ 'go', 'build -o $(FILE_TITLE)$', g:SingleCompile_common_run_command)
+                \ 'go', 'build -o $(FILE_EXEC)$', g:SingleCompile_common_run_command)
     call SingleCompile#SetPriority('go', 'Go', 20)
 endfunction
 


### PR DESCRIPTION
On Windows, SingleCompile set output file name to just FILE_TITLE, need to add .exe extension
