### PR TITLE
Fixes Rust support

### DIFF
--- a/autoload/SingleCompile/templates/rust.vim
+++ b/autoload/SingleCompile/templates/rust.vim
@@ -18,8 +18,8 @@
 " check doc/SingleCompile.txt for more information
 
 function! SingleCompile#templates#rust#Initialize()
-    call SingleCompile#SetCompilerTemplate('rust', 'rust', 'Rust',
-                \ 'rust', 'build -o $(FILE_TITLE)$', g:SingleCompile_common_run_command)
+    call SingleCompile#SetCompilerTemplate('rust', 'rustc', 'Rust',
+                \ 'rustc', '-o $(FILE_TITLE)$', g:SingleCompile_common_run_command)
 endfunction
 
 "vim703: cc=78


### PR DESCRIPTION
'rust' command was removed from Rust distribution. Now using 'rustc'.
