### PR TITLE
SCViewResult options, improve ShowResultAfterRun

### DIFF
--- a/autoload/SingleCompile.vim
+++ b/autoload/SingleCompile.vim
@@ -527,8 +527,8 @@ function! s:Initialize() "{{{1
         let g:SingleCompile_resultsize = 5
     endif
 
-    if !exists('g:SingleCompileRun_split')
-        let g:SingleCompileRun_split = 'split'
+    if !exists('g:SingleCompile_split')
+        let g:SingleCompile_split = 'split'
     endif
 
     if !exists('g:SingleCompile_showquickfixiferror') ||
@@ -1586,7 +1586,7 @@ function! SingleCompile#ViewResult(async) " view the running result {{{1
     " else clear it, but leave it there to be refilled
     if l:result_bufnr == -1
         exec 'rightbelow '.g:SingleCompile_resultsize.
-                    \g:SingleCompileRun_split.' __SINGLE_COMPILE_RUN_RESULT__'
+                    \g:SingleCompile_split.' __SINGLE_COMPILE_RUN_RESULT__'
         setl noswapfile buftype=nofile bufhidden=wipe foldcolumn=0 nobuflisted
     else
         let l:result_bufwinnr = bufwinnr(l:result_bufnr)

--- a/doc/SingleCompile.txt
+++ b/doc/SingleCompile.txt
@@ -379,16 +379,16 @@ or
 <
 It is also possible to select between vertical or horizontal split depending
 on the current window width. To achieve this it is necessary to update the
-option on the mapping that calls |:SCCompileRun|. This can be done in a new
-mapping, or replacing the default mapping to |:SCCompileRun|, <F10>:
+plugin options on the mapping that calls |:SCCompileRun|. This can be done in
+a new mapping, or replacing the default mapping to |:SCCompileRun|, <F10>:
 >
- nnoremap <F10> :update \| call SingleCompileSplit() \| SCCompileRun<CR>
+ nnoremap <F10> :call SingleCompileSplit() \| SCCompileRun<CR>
  function! SingleCompileSplit()
     if winwidth(0) > 160
-       let g:SingleCompileRun_split = "vsplit"
+       let g:SingleCompile_split = "vsplit"
        let g:SingleCompile_resultsize = winwidth(0)/2
     else
-       let g:SingleCompileRun_split = "split"
+       let g:SingleCompile_split = "split"
        let g:SingleCompile_resultsize = 15
     endif
  endfunction


### PR DESCRIPTION
1) Option `SingleCompileRun_split` allows for vertical splits
2) Rename `g:SingleCompile_resultheight` to use it as width for vertical splits
3) Create a mapping to make it easier to close the result window
4) Substitute `exec "g/.*/d"`, as it interferes with 'hlsearch', i.e., if 'hlsearch' is set all the text on the result window is highlighted and the previous search is replaced.
5) When the  g:SingleCompile_showresultafterrun option is active:
- Do not show the regular output on successful runs
- Close the result windows when compilation fails
