### PR TITLE
Preserve alternate file when showing results

### DIFF
--- a/autoload/SingleCompile.vim
+++ b/autoload/SingleCompile.vim
@@ -1589,7 +1589,7 @@ function! SingleCompile#ViewResult(async) " view the running result {{{1
     " if the __SINGLE_COMPILE_RUN_RESULT__ buffer doesn't exist, make one
     " else clear it, but leave it there to be refilled
     if l:result_bufnr == -1
-        exec 'rightbelow '.g:SingleCompile_resultsize.
+        exec 'keepalt rightbelow '.g:SingleCompile_resultsize.
                     \g:SingleCompile_split.' __SINGLE_COMPILE_RUN_RESULT__'
         setl noswapfile buftype=nofile bufhidden=wipe foldcolumn=0 nobuflisted
     else


### PR DESCRIPTION
It can be distracting the change in the alternate file caused by the creation of the result window. Despite it usually doesn't cause problems after the window is created, it can be unexpected after a compilation error, subsequent correction and result window is recreated:

1. vim has a single window containing fileA
1. :SCCompileRun successful  --> fileA on the left window, `__SINGLE_COMPILE_RUN_RESULT__` on the right window
1. open fileB on the left window
1. <kbd>Ctrl</kbd>+<kbd>^</kbd> on the left window goes back to fileA 
1. :SCCompileRun successful
1. <kbd>Ctrl</kbd>+<kbd>^</kbd> on the left window goes back to fileB, repeating goes back to fileA
1. changes fileA, :SCCompileRun fails -> fileA on top window, compilation on quickfix ( `__SINGLE_COMPILE_RUN_RESULT__`  closed)
1. correct fileA, :SCCompileRun successful  --> fileA on the left window, `__SINGLE_COMPILE_RUN_RESULT__` on the right window
1. <kbd>Ctrl</kbd>+<kbd>^</kbd> on the left window changes it to `__SINGLE_COMPILE_RUN_RESULT__` *instead of going to fileB*