### PR TITLE
add support for kotlin script

### DIFF
--- a/autoload/SingleCompile.vim
+++ b/autoload/SingleCompile.vim
@@ -644,6 +644,7 @@ function! s:Initialize() "{{{1
                 \ 'java',
                 \ 'javascript',
                 \ 'ksh',
+                \ 'kotlin',
                 \ 'lisp',
                 \ 'ls',
                 \ 'lua',

--- a/autoload/SingleCompile/templates/kotlin.vim
+++ b/autoload/SingleCompile/templates/kotlin.vim
@@ -17,10 +17,10 @@
 
 " check doc/SingleCompile.txt for more information
 
-function! SingleCompile#templates#swift#Initialize()
-    call SingleCompile#SetCompilerTemplate('swift', 'swiftc', 'swiftc',
-                \ 'swiftc', ' -o $(FILE_EXEC)$', g:SingleCompile_common_run_command)
-    call SingleCompile#SetPriority('swift', 'swiftc', 20)
+function! SingleCompile#templates#kotlin#Initialize()
+    call SingleCompile#SetCompilerTemplate('kotlin', 'kotlinc', 'kotlinc',
+                \ 'kotlinc', ' -script $(FILE_NAME)$', "")
+    call SingleCompile#SetPriority('kotlin', 'kotlinc', 20)
 endfunction
 
 "vim703: cc=78


### PR DESCRIPTION
need this plug to make vim identify "kotlin script"  by ".kts"
https://github.com/udalov/kotlin-vim

only support ".kts", no ".kt"