### PR TITLE
Avoid replacing quickfix window - fix #58

### DIFF
--- a/autoload/SingleCompile.vim
+++ b/autoload/SingleCompile.vim
@@ -1423,6 +1423,9 @@ function! s:CompileRunInternal(comp_param, async) " {{{1
 
     let l:cur_filepath2 = expand('%:p')
 
+    if &buftype == 'quickfix'
+        wincmd p
+    endif
     if l:cur_filepath != l:cur_filepath2
         exec 'edit ' . l:cur_filepath
     endif
@@ -1435,6 +1438,9 @@ function! s:CompileRunInternal(comp_param, async) " {{{1
                     \.'output if the program has terminated.'
     endif
 
+    if &buftype == 'quickfix'
+        wincmd p
+    endif
     if l:cur_filepath != l:cur_filepath2
         exec 'edit ' . l:cur_filepath2
     endif

--- a/autoload/SingleCompile.vim
+++ b/autoload/SingleCompile.vim
@@ -1423,6 +1423,8 @@ function! s:CompileRunInternal(comp_param, async) " {{{1
 
     let l:cur_filepath2 = expand('%:p')
 
+    " only use l:cur_filepath on a regular window. If the cursor is on
+    " quickfix jump to the last accessed window
     if &buftype == 'quickfix'
         wincmd p
     endif
@@ -1438,6 +1440,8 @@ function! s:CompileRunInternal(comp_param, async) " {{{1
                     \.'output if the program has terminated.'
     endif
 
+    " only use l:cur_filepath on a regular window. If the cursor is on
+    " quickfix jump to the last accessed window
     if &buftype == 'quickfix'
         wincmd p
     endif


### PR DESCRIPTION
It seems the workaround for quickfix switching to another file fails if the quickfix opens due to warnings.

These changes were tested on gVim in Windows (version 8.2, patches 1-1770) and in Linux (version 8.2, patches 1-1719).